### PR TITLE
Fix ChamberPage params handling

### DIFF
--- a/src/app/chamber/[id]/page.tsx
+++ b/src/app/chamber/[id]/page.tsx
@@ -5,21 +5,19 @@ import { notFound } from 'next/navigation';
 import ChamberClientWrapper from '@/components/ChamberClientWrapper';
 
 type PageProps = {
-  // Next.js App Router now passes params as a Promise
-  params: Promise<{ id: string }>;
+  params: { id: string };
 };
 
 /**
  * Server Component for rendering a Chamber page.
  *
- * - Awaits the `params` Promise to get the chamber ID from the URL.
+ * - Reads the chamber ID from the URL params.
  * - Finds the corresponding chamber from the data.
  * - If not found, triggers Next.js 404 page.
  * - Renders the client-side ChamberClientWrapper with the chamberId prop.
  */
-export default async function ChamberPage({ params }: PageProps) {
-  // Await params Promise to get actual params object
-  const { id } = await params;
+export default function ChamberPage({ params }: PageProps) {
+  const { id } = params;
 
   // Parse chamber ID as number
   const chamberId = Number(id);


### PR DESCRIPTION
## Summary
- correct `params` typing in `ChamberPage`
- remove unnecessary async logic and outdated comments

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460c5347988331a14208f8a24c1049