### PR TITLE
Add autoprefixer to PostCSS setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "typescript": "^5",
     "@types/jest": "^29.5.0",
     "jest": "^29.7.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "^29.1.1",
+    "autoprefixer": "^10"
   }
 }

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,8 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: [
+    "@tailwindcss/postcss",
+    "autoprefixer",
+  ],
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- include `autoprefixer` in `postcss.config.mjs`
- add `autoprefixer` as a dev dependency in `package.json`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461c2765648331822ea9cdf6c3ae86