### PR TITLE
Add unit tests for pathfinding and Supabase client

### DIFF
--- a/__tests__/pathfinding.test.ts
+++ b/__tests__/pathfinding.test.ts
@@ -1,0 +1,61 @@
+import { findPath, Position } from '../src/lib/pathfinding';
+
+describe('findPath', () => {
+  const createGrid = (rows: number, cols: number, walls: Position[] = []) => {
+    const wallSet = new Set(walls.map(([r, c]) => `${r},${c}`));
+    return (row: number, col: number) => {
+      if (row < 0 || col < 0 || row >= rows || col >= cols) return false;
+      return !wallSet.has(`${row},${col}`);
+    };
+  };
+
+  test('finds shortest path in open grid', () => {
+    const isWalkable = createGrid(3, 3);
+    const path = findPath([0, 0], [2, 2], (pos) => {
+      const deltas = [
+        [-1, 0],
+        [1, 0],
+        [0, -1],
+        [0, 1],
+      ];
+      const neighbors: Position[] = [];
+      for (const [dr, dc] of deltas) {
+        const nr = pos[0] + dr;
+        const nc = pos[1] + dc;
+        if (isWalkable(nr, nc)) neighbors.push([nr, nc]);
+      }
+      return neighbors;
+    });
+    expect(path).toEqual([
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [2, 1],
+      [2, 2],
+    ]);
+  });
+
+  test('returns null when no path exists', () => {
+    const isWalkable = createGrid(3, 3, [
+      [1, 0],
+      [1, 1],
+      [1, 2],
+    ]);
+    const path = findPath([0, 0], [2, 2], (pos) => {
+      const deltas = [
+        [-1, 0],
+        [1, 0],
+        [0, -1],
+        [0, 1],
+      ];
+      const neighbors: Position[] = [];
+      for (const [dr, dc] of deltas) {
+        const nr = pos[0] + dr;
+        const nc = pos[1] + dc;
+        if (isWalkable(nr, nc)) neighbors.push([nr, nc]);
+      }
+      return neighbors;
+    });
+    expect(path).toBeNull();
+  });
+});

--- a/__tests__/supabaseClient.test.ts
+++ b/__tests__/supabaseClient.test.ts
@@ -1,0 +1,28 @@
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({ fake: true })),
+}));
+
+describe('supabaseClient', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://supabase.test';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon';
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  test('initializes createClient with env vars', () => {
+    const { createClient } = require('@supabase/supabase-js');
+    const { supabase } = require('../src/lib/supabaseClient');
+    expect(createClient).toHaveBeenCalledWith(
+      'http://supabase.test',
+      'anon'
+    );
+    expect(supabase).toEqual({ fake: true });
+  });
+});

--- a/src/lib/pathfinding.ts
+++ b/src/lib/pathfinding.ts
@@ -1,0 +1,84 @@
+export type Position = [number, number];
+
+export type NeighborFn = (pos: Position) => Position[];
+
+export type HeuristicFn = (a: Position, b: Position) => number;
+
+export type PathNode = {
+  position: Position;
+  g: number;
+  h: number;
+  f: number;
+  parent: PathNode | null;
+};
+
+export const manhattan: HeuristicFn = ([r1, c1], [r2, c2]) =>
+  Math.abs(r1 - r2) + Math.abs(c1 - c2);
+
+/**
+ * A generic A* pathfinding implementation.
+ * @param start start position
+ * @param end end position
+ * @param getNeighbors function returning walkable neighbors of a position
+ * @param heuristic distance heuristic (defaults to Manhattan)
+ * @returns array of positions representing the shortest path or null if none
+ */
+export function findPath(
+  start: Position,
+  end: Position,
+  getNeighbors: NeighborFn,
+  heuristic: HeuristicFn = manhattan
+): Position[] | null {
+  const openList: PathNode[] = [];
+  const closed = new Set<string>();
+  const key = (p: Position) => `${p[0]}-${p[1]}`;
+
+  openList.push({
+    position: start,
+    g: 0,
+    h: heuristic(start, end),
+    f: heuristic(start, end),
+    parent: null,
+  });
+
+  while (openList.length > 0) {
+    openList.sort((a, b) => a.f - b.f);
+    const current = openList.shift()!;
+    closed.add(key(current.position));
+
+    if (current.position[0] === end[0] && current.position[1] === end[1]) {
+      const path: Position[] = [];
+      let node: PathNode | null = current;
+      while (node) {
+        path.push(node.position);
+        node = node.parent;
+      }
+      return path.reverse();
+    }
+
+    for (const n of getNeighbors(current.position)) {
+      if (closed.has(key(n))) continue;
+
+      const gScore = current.g + 1;
+      const hScore = heuristic(n, end);
+      const fScore = gScore + hScore;
+
+      const existing = openList.find(
+        (node) => node.position[0] === n[0] && node.position[1] === n[1]
+      );
+
+      if (existing && existing.g <= gScore) continue;
+
+      if (existing) {
+        existing.g = gScore;
+        existing.h = hScore;
+        existing.f = fScore;
+        existing.parent = current;
+      } else {
+        openList.push({ position: n, g: gScore, h: hScore, f: fScore, parent: current });
+      }
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add generic A* implementation in `src/lib/pathfinding.ts`
- test new pathfinding logic
- test Supabase client initialization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846fcca6ec08331b023a061993106df