### PR TITLE
Add runtime checks for Supabase env vars

### DIFF
--- a/__tests__/supabaseClient.test.ts
+++ b/__tests__/supabaseClient.test.ts
@@ -25,4 +25,12 @@ describe('supabaseClient', () => {
     );
     expect(supabase).toEqual({ fake: true });
   });
+
+  test('throws when env vars are missing', () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    jest.resetModules();
+    expect(() => require('../src/lib/supabaseClient')).toThrow(
+      /Supabase environment variables missing/
+    );
+  });
 });

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -8,15 +8,27 @@
  * Make sure to define the following environment variables in your .env.local or Vercel:
  * - NEXT_PUBLIC_SUPABASE_URL
  * - NEXT_PUBLIC_SUPABASE_ANON_KEY
- * 
- * The non-null assertion operator (!) tells TypeScript we guarantee these env vars exist.
+ *
+ * The variables are validated at runtime to provide clear feedback during
+ * development if they're missing.
  */
 
 import { createClient } from '@supabase/supabase-js';
 
 // Read environment variables for Supabase project URL and anon key
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+// Provide helpful feedback if variables are missing
+if (!supabaseUrl || !supabaseAnonKey) {
+  const missing: string[] = [];
+  if (!supabaseUrl) missing.push('NEXT_PUBLIC_SUPABASE_URL');
+  if (!supabaseAnonKey) missing.push('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  throw new Error(
+    `Supabase environment variables missing: ${missing.join(', ')}. ` +
+      'Check your .env.local or Vercel project settings.'
+  );
+}
 
 // Create the Supabase client with URL and anon key
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- validate required Supabase env variables at runtime
- throw clear error if env vars are missing
- test missing env variable behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846ff76ff088331bef0cc773cb48554