### PR TITLE
Fix Next.js PageProps naming issue

### DIFF
--- a/src/app/chamber/[id]/page.tsx
+++ b/src/app/chamber/[id]/page.tsx
@@ -4,7 +4,7 @@ import { chambers } from '@/data/chambers';
 import { notFound } from 'next/navigation';
 import ChamberClientWrapper from '@/components/ChamberClientWrapper';
 
-type PageProps = {
+type ChamberPageProps = {
   params: { id: string };
 };
 
@@ -16,7 +16,7 @@ type PageProps = {
  * - If not found, triggers Next.js 404 page.
  * - Renders the client-side ChamberClientWrapper with the chamberId prop.
  */
-export default function ChamberPage({ params }: PageProps) {
+export default function ChamberPage({ params }: ChamberPageProps) {
   const { id } = params;
 
   // Parse chamber ID as number


### PR DESCRIPTION
## Summary
- rename `PageProps` type in chamber page to avoid conflicts with Next.js generated types

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470bd561d483319b98e76fe4b578da